### PR TITLE
Add netlify cache

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -72,6 +72,9 @@ const plugins = [
       icon: `src/images/logo.svg`
     }
   },
+  // Automatically restores your cache and caches new files within the Netlify cache folder.
+  //   To reset the cache, hit the Clear build cache checkbox in the Netlify app.
+  'gatsby-plugin-netlify-cache',
   'gatsby-plugin-netlify'
 ]
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "gatsby-plugin-manifest": "2.2.20",
     "gatsby-plugin-mdx": "1.0.41",
     "gatsby-plugin-netlify": "2.1.13",
+    "gatsby-plugin-netlify-cache": "^1.2.0",
     "gatsby-plugin-nprogress": "2.1.7",
     "gatsby-plugin-offline": "^3.0.11",
     "gatsby-plugin-react-helmet": "3.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6166,6 +6166,15 @@ fs-extra@^4.0.1, fs-extra@^4.0.2:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -6410,6 +6419,14 @@ gatsby-plugin-mdx@1.0.41:
     unist-util-map "^1.0.5"
     unist-util-remove "^1.0.3"
     unist-util-visit "^1.4.1"
+
+gatsby-plugin-netlify-cache@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-netlify-cache/-/gatsby-plugin-netlify-cache-1.2.0.tgz#e68db9c5bd4ae103b4589f9be2a3cb9958750788"
+  integrity sha512-unt4mAVpC0JzwZSo8KQV4P/trDHkr3PeTWDF5Hijw9jGfNQIWXbcj9nYljAVg7HCich6E6b27Q+zuf53InwpDQ==
+  dependencies:
+    babel-runtime "^6.26.0"
+    fs-extra "^7.0.0"
 
 gatsby-plugin-netlify@2.1.13:
   version "2.1.13"


### PR DESCRIPTION
This should speed up image generation a lot. It checks the md5sum and skips them if nothing changed.