### PR TITLE
feat: add download export options to recipe page to make re-downloading faster

### DIFF
--- a/src/components/draft/draft.js
+++ b/src/components/draft/draft.js
@@ -27,7 +27,7 @@ import { withoutBreasts, withBreasts } from '@freesewing/models'
 import Blockquote from '@freesewing/components/Blockquote'
 import Icon from '@freesewing/components/Icon'
 import { useStaticQuery, graphql } from 'gatsby'
-import { MDXRenderer } from "gatsby-plugin-mdx"
+import { MDXRenderer } from 'gatsby-plugin-mdx'
 import { MDXProvider } from '@mdx-js/react'
 import Robot from '@freesewing/components/Robot'
 
@@ -62,7 +62,7 @@ const DraftPage = props => {
     }
   }
   useEffect(() => {
-    props.updateGist((display === "export" ? false : true), 'settings', 'embed')
+    props.updateGist(display === 'export' ? false : true, 'settings', 'embed')
     if (props.recreate) {
       // Recreate from recipe
       props.app.backend.loadRecipe(props.recipe, handleRecipeResult)
@@ -82,7 +82,12 @@ const DraftPage = props => {
         measurements[m] = props.app.models[props.model].measurements[m]
       }
       props.updateGist(measurements, 'settings', 'measurements')
-      props.app.frontend.setTitle(props.app.frontend.intl.formatMessage({id: "app.newPatternForModel"}, {pattern: capitalize(props.pattern), model: props.app.models[props.model].name }))
+      props.app.frontend.setTitle(
+        props.app.frontend.intl.formatMessage(
+          { id: 'app.newPatternForModel' },
+          { pattern: capitalize(props.pattern), model: props.app.models[props.model].name }
+        )
+      )
       setReady(true)
     }
   }, [props.pattern, props.model, props.recipe])
@@ -180,7 +185,7 @@ const DraftPage = props => {
 
   let pattern, error, patternProps
   try {
-    pattern = new patterns[(capitalize(design))](props.gist.settings).use(i18nPlugin, {
+    pattern = new patterns[capitalize(design)](props.gist.settings).use(i18nPlugin, {
       strings: patternTranslations
     })
     if (display === 'compare') {
@@ -265,7 +270,7 @@ const DraftPage = props => {
           style={styles.button}
           onClick={() => setFit(!fit)}
         >
-          {fit ? <ZoomInIcon data-test="zoomIn"/> : <ZoomOutIcon data-test="zoomOut"/>}
+          {fit ? <ZoomInIcon data-test="zoomIn" /> : <ZoomOutIcon data-test="zoomOut" />}
         </Button>
       )}
       <Button
@@ -315,8 +320,16 @@ const DraftPage = props => {
       variant="fullWidth"
       style={styles.tabs}
     >
-      <Tab icon={<SettingsIcon />} style={styles.tab[tab === 0 ? 'active' : 'inactive']} data-test="config-tab"/>
-      <Tab icon={<MenuIcon />} style={styles.tab[tab === 1 ? 'active' : 'inactive']} data-test="menu-tab"/>
+      <Tab
+        icon={<SettingsIcon />}
+        style={styles.tab[tab === 0 ? 'active' : 'inactive']}
+        data-test="config-tab"
+      />
+      <Tab
+        icon={<MenuIcon />}
+        style={styles.tab[tab === 1 ? 'active' : 'inactive']}
+        data-test="menu-tab"
+      />
     </Tabs>
   ]
   if (tab === 0)
@@ -344,14 +357,24 @@ const DraftPage = props => {
   let main, helpTitle
   if (display === 'export') {
     main = (
-      <ExportPattern setDisplay={setDisplay} app={props.app} gist={props.gist} pattern={patterns[capitalize(design)]} />
+      <ExportPattern
+        setDisplay={setDisplay}
+        app={props.app}
+        gist={props.gist}
+        pattern={patterns[capitalize(design)]}
+      />
     )
   } else if (display === 'save') {
     main = <SaveRecipe setDisplay={setDisplay} app={props.app} gist={props.gist} />
   } else if (display === 'help') {
     let close = (
       <div style={styles.buttons}>
-        <Button variant="contained" color="primary" onClick={() => setDisplay('draft')} data-test="back">
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={() => setDisplay('draft')}
+          data-test="back"
+        >
           <FormattedMessage id="app.back" />
         </Button>
       </div>
@@ -363,7 +386,7 @@ const DraftPage = props => {
     helpTitle = topicDocs[eventValue.toLowerCase()].title
     main = (
       <React.Fragment>
-        <div data-test='mdx'>
+        <div data-test="mdx">
           <MDXProvider components={props.components}>
             <MDXRenderer>{topicDocs[eventValue.toLowerCase()].body}</MDXRenderer>
           </MDXProvider>
@@ -373,7 +396,7 @@ const DraftPage = props => {
     )
   } else {
     main = error ? (
-      <div style={styles.errorWrapper} data-test='error'>
+      <div style={styles.errorWrapper} data-test="error">
         <Blockquote type="warning">
           {error.message === 'cannot scale this curve. Try reducing it first.' ? (
             <React.Fragment>

--- a/src/components/draft/export-pattern.js
+++ b/src/components/draft/export-pattern.js
@@ -12,8 +12,6 @@ const ExportPattern = props => {
   const gist = { ...props.gist }
   delete gist.settings.embed
 
-  console.log(props)
-
   const tiler = useTiler({
     intl: props.app.frontend.intl,
     showNotification: props.app.frontend.showNotification,

--- a/src/components/draft/export-pattern.js
+++ b/src/components/draft/export-pattern.js
@@ -12,6 +12,8 @@ const ExportPattern = props => {
   const gist = { ...props.gist }
   delete gist.settings.embed
 
+  console.log(props)
+
   const tiler = useTiler({
     intl: props.app.frontend.intl,
     showNotification: props.app.frontend.showNotification,
@@ -23,7 +25,10 @@ const ExportPattern = props => {
       if (format === 'json') exportJsonRecipe(gist)
       else if (format === 'yaml') exportYamlRecipe(gist)
     } else {
-      const svg = new props.pattern({...props.gist.settings, embed: false})
+      const svg = new props.pattern({
+        ...props.gist.settings,
+        embed: false
+      })
         .use(theme)
         .use(i18n, {
           strings: patternTranslations
@@ -84,13 +89,18 @@ const ExportPattern = props => {
   if (props.app.frontend.tablet) styles.column.width = '45%'
   if (props.app.frontend.mobile) styles.column.width = '95%'
 
-  const cancel = (
+  const cancel = props.setDisplay ? (
     <p style={{ textAlign: 'right' }}>
-      <Button variant="outlined" color="primary" onClick={() => props.setDisplay('draft')} data-test="cancel">
+      <Button
+        variant="outlined"
+        color="primary"
+        onClick={() => props.setDisplay('draft')}
+        data-test="cancel"
+      >
         <FormattedMessage id="app.cancel" />
       </Button>
     </p>
-  )
+  ) : null
 
   const btnProps = {
     size: 'large',
@@ -104,7 +114,9 @@ const ExportPattern = props => {
       {cancel}
       <div style={styles.wrapper}>
         <div style={styles.column} data-test="printing">
-          <h5><FormattedMessage id="app.exportForPrinting" /></h5>
+          <h5>
+            <FormattedMessage id="app.exportForPrinting" />
+          </h5>
           {['a4', 'a3', 'a2', 'a1', 'a0', 'letter', 'tabloid'].map(size => (
             <Button {...btnProps} onClick={() => handleExport('tile', size)} data-test={size}>
               {size} PDF
@@ -112,7 +124,9 @@ const ExportPattern = props => {
           ))}
         </div>
         <div style={styles.column} data-test="editing">
-          <h5><FormattedMessage id="app.exportForEditing" /></h5>
+          <h5>
+            <FormattedMessage id="app.exportForEditing" />
+          </h5>
           {['svg', 'postscript', 'pdf'].map(format => (
             <Button {...btnProps} onClick={() => handleExport('raw', format)} data-test={format}>
               {format}
@@ -120,7 +134,9 @@ const ExportPattern = props => {
           ))}
         </div>
         <div style={styles.column} data-test="export">
-          <h5><FormattedMessage id="app.exportRecipe" /></h5>
+          <h5>
+            <FormattedMessage id="app.exportRecipe" />
+          </h5>
           {['json', 'yaml'].map(format => (
             <Button {...btnProps} onClick={() => handleExport('recipe', format)} data-test={format}>
               {format}

--- a/src/components/recipes/show.js
+++ b/src/components/recipes/show.js
@@ -1,10 +1,13 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import Button from '@material-ui/core/Button'
+import capitalize from '@freesewing/utils/capitalize'
 import Markdown from 'react-markdown'
 import RecipeCode from './recipe'
+import ExportPattern from '../draft/export-pattern'
+import patterns from '../draft/patterns'
 
-const ShowRecipe = ( props) => {
+const ShowRecipe = props => {
   const styles = {
     button: {
       marginLeft: '1rem'
@@ -16,12 +19,13 @@ const ShowRecipe = ( props) => {
       color: '#fff'
     }
   }
-  if (props.ownRecipe) styles.draftButton = {
-    marginLeft: '1rem',
-    background: '#228be6',
-    borderColor: '#1971c2',
-    color: '#fff'
-  }
+  if (props.ownRecipe)
+    styles.draftButton = {
+      marginLeft: '1rem',
+      background: '#228be6',
+      borderColor: '#1971c2',
+      color: '#fff'
+    }
 
   if (props.app.frontend.mobile) {
     styles.table.margin = '0 -1.5rem'
@@ -29,15 +33,13 @@ const ShowRecipe = ( props) => {
   }
 
   return (
-    <React.Fragment>
-      {
-        typeof props.recipe.notes === 'undefined' ||
-        props.recipe.notes === '' ? null : (
-          <Markdown source={props.recipe.notes || ''} />
+    <>
+      {typeof props.recipe.notes === 'undefined' || props.recipe.notes === '' ? null : (
+        <Markdown source={props.recipe.notes || ''} />
       )}
-      <RecipeCode recipe={props.recipe} />
+
       <p style={{ textAlign: 'right' }}>
-        { props.ownRecipe ? (
+        {props.ownRecipe ? (
           <Button
             color="inherit"
             style={styles.deleteButton}
@@ -45,7 +47,8 @@ const ShowRecipe = ( props) => {
             onClick={() => props.app.backend.removeRecipe(props.recipe.handle)}
           >
             <FormattedMessage id="app.remove" />
-          </Button> ) : null }
+          </Button>
+        ) : null}
         <Button
           color="primary"
           style={styles.draftButton}
@@ -54,17 +57,26 @@ const ShowRecipe = ( props) => {
         >
           <FormattedMessage id="app.recreate" />
         </Button>
-        { props.ownRecipe ? (
-        <Button
-          color="primary"
-          style={styles.button}
-          href={'/recipes/' + props.recipe.handle + '/edit'}
-          variant="contained"
-        >
-          <FormattedMessage id="app.update" />
-          </Button> ) : null }
+        {props.ownRecipe ? (
+          <Button
+            color="primary"
+            style={styles.button}
+            href={'/recipes/' + props.recipe.handle + '/edit'}
+            variant="contained"
+          >
+            <FormattedMessage id="app.update" />
+          </Button>
+        ) : null}
       </p>
-    </React.Fragment>
+
+      <ExportPattern
+        app={props.app}
+        gist={props.recipe.recipe}
+        pattern={patterns[capitalize(props.recipe.recipe.pattern)]}
+      />
+
+      <RecipeCode recipe={props.recipe} />
+    </>
   )
 }
 

--- a/src/components/recipes/show.js
+++ b/src/components/recipes/show.js
@@ -8,6 +8,8 @@ import ExportPattern from '../draft/export-pattern'
 import patterns from '../draft/patterns'
 
 const ShowRecipe = props => {
+  const { recipe, ownRecipe, app } = props
+
   const styles = {
     button: {
       marginLeft: '1rem'
@@ -19,7 +21,7 @@ const ShowRecipe = props => {
       color: '#fff'
     }
   }
-  if (props.ownRecipe)
+  if (ownRecipe)
     styles.draftButton = {
       marginLeft: '1rem',
       background: '#228be6',
@@ -27,55 +29,53 @@ const ShowRecipe = props => {
       color: '#fff'
     }
 
-  if (props.app.frontend.mobile) {
+  if (app.frontend.mobile) {
     styles.table.margin = '0 -1.5rem'
     styles.table.width = 'calc(100% + 3rem)'
   }
 
   return (
     <>
-      {typeof props.recipe.notes === 'undefined' || props.recipe.notes === '' ? null : (
-        <Markdown source={props.recipe.notes || ''} />
-      )}
+      {recipe.notes && <Markdown source={recipe.notes} />}
 
       <p style={{ textAlign: 'right' }}>
-        {props.ownRecipe ? (
+        {ownRecipe && (
           <Button
             color="inherit"
             style={styles.deleteButton}
             variant="outlined"
-            onClick={() => props.app.backend.removeRecipe(props.recipe.handle)}
+            onClick={() => app.backend.removeRecipe(recipe.handle)}
           >
             <FormattedMessage id="app.remove" />
           </Button>
-        ) : null}
+        )}
         <Button
           color="primary"
           style={styles.draftButton}
-          href={'/recreate/' + props.recipe.handle}
+          href={'/recreate/' + recipe.handle}
           variant="contained"
         >
           <FormattedMessage id="app.recreate" />
         </Button>
-        {props.ownRecipe ? (
+        {ownRecipe && (
           <Button
             color="primary"
             style={styles.button}
-            href={'/recipes/' + props.recipe.handle + '/edit'}
+            href={'/recipes/' + recipe.handle + '/edit'}
             variant="contained"
           >
             <FormattedMessage id="app.update" />
           </Button>
-        ) : null}
+        )}
       </p>
 
       <ExportPattern
-        app={props.app}
-        gist={props.recipe.recipe}
-        pattern={patterns[capitalize(props.recipe.recipe.pattern)]}
+        app={app}
+        gist={recipe.recipe}
+        pattern={patterns[capitalize(recipe.recipe.pattern)]}
       />
 
-      <RecipeCode recipe={props.recipe} />
+      <RecipeCode recipe={recipe} />
     </>
   )
 }


### PR DESCRIPTION
I always found it a bit cumbersome to go through recreate and made a small adjustment so we can show exports on the recipe page as well.

<img width="1449" alt="muslin-v1" src="https://user-images.githubusercontent.com/209089/70096524-e532d380-15ec-11ea-98f5-424676c560c7.png">
