### PR TITLE
chore: Added @dfbean as a contributor

### DIFF
--- a/contributors.yaml
+++ b/contributors.yaml
@@ -12,6 +12,15 @@ teams:
   - patternDesign
 
 people:
+  - name: Deb
+    img: ../avatar.svg
+    github: dfbean
+    discord: Deb
+    teams:
+      - patternDesign
+    tags:
+      - patternDesign
+      - patternTesting
   - name: Amy
     img: amy.jpg
     github: amysews


### PR DESCRIPTION
This commit will add @dfbean to the contributors file.
The result is that she will be listed on the website as a contributor.
For this reason, @dfbean should approve this before this gets
merged.

In other words, this commit is the papertrail for the opt-in way of
adding contributors to the site.

Notes:

 - I used `Deb` here as a name
 - I did not add a picture only because that seems to be what you
 prefer