### PR TITLE
Fix person edition pages

### DIFF
--- a/src/pages/account/people/_person/avatar.js
+++ b/src/pages/account/people/_person/avatar.js
@@ -87,7 +87,7 @@ const Page = (props) => {
           size="large"
           variant="outlined"
           color="primary"
-          href={`/people/${props.person}/`}
+          href={`/account/people/${props.person}/`}
           data-test="cancel"
         >
           <FormattedMessage id="app.cancel" />

--- a/src/pages/account/people/_person/chest.js
+++ b/src/pages/account/people/_person/chest.js
@@ -15,14 +15,13 @@ const Page = (props) => {
   if (typeof app.people[props.person] === 'undefined') return null
 
   // Figure out inital state in a SSR-safe way
-  const initial = false
-  if (
+  const initial =
     app.people &&
     props.params.person &&
     app.people[props.params.person] &&
     app.people[props.params.person].breasts
-  )
-    initial = app.people[props.params.person].breasts
+      ? app.people[props.params.person].breasts
+      : false
 
   const [breasts, setBreasts] = useState(initial)
 

--- a/src/pages/account/people/_person/chest.js
+++ b/src/pages/account/people/_person/chest.js
@@ -49,9 +49,19 @@ const Page = (props) => {
           label={app.translate('app.withoutBreasts')}
         />
       </RadioGroup>
-      <p>
+      <p style={{ textAlign: 'right' }}>
         <Button
           size="large"
+          style={{ marginLeft: '1rem' }}
+          variant="outlined"
+          color="primary"
+          href={`/account/people/${props.person}/`}
+        >
+          <FormattedMessage id="app.cancel" />
+        </Button>
+        <Button
+          size="large"
+          style={{ marginLeft: '1rem' }}
           variant="contained"
           color="primary"
           onClick={() =>

--- a/src/pages/account/people/_person/name.js
+++ b/src/pages/account/people/_person/name.js
@@ -49,7 +49,7 @@ const Page = (props) => {
           style={{ marginLeft: '1rem' }}
           variant="outlined"
           color="primary"
-          href={`/people/${props.person}/`}
+          href={`/account/people/${props.person}/`}
         >
           <FormattedMessage id="app.cancel" />
         </Button>

--- a/src/pages/account/people/_person/notes.js
+++ b/src/pages/account/people/_person/notes.js
@@ -47,7 +47,7 @@ const Page = (props) => {
           size="large"
           variant="outlined"
           color="primary"
-          href={'/people/' + props.person}
+          href={'/account/people/' + props.person}
           data-test="cancel"
         >
           <FormattedMessage id="app.cancel" />

--- a/src/pages/account/people/_person/units.js
+++ b/src/pages/account/people/_person/units.js
@@ -15,14 +15,13 @@ const Page = (props) => {
   if (typeof app.people[props.person] === 'undefined') return null
 
   // Figure out inital state in a SSR-safe way
-  const initial = false
-  if (
+  const initial =
     app.people &&
     props.params.person &&
     app.people[props.params.person] &&
     app.people[props.params.person].units
-  )
-    initial = app.people[props.params.person].units
+      ? app.people[props.params.person].units
+      : false
 
   const [units, setUnits] = useState(initial)
 

--- a/src/pages/account/people/_person/units.js
+++ b/src/pages/account/people/_person/units.js
@@ -45,9 +45,19 @@ const Page = (props) => {
           label={app.translate('app.imperialUnits')}
         />
       </RadioGroup>
-      <p>
+      <p style={{ textAlign: 'right' }}>
         <Button
           size="large"
+          style={{ marginLeft: '1rem' }}
+          variant="outlined"
+          color="primary"
+          href={`/account/people/${props.person}/`}
+        >
+          <FormattedMessage id="app.cancel" />
+        </Button>
+        <Button
+          size="large"
+          style={{ marginLeft: '1rem' }}
           variant="contained"
           color="primary"
           onClick={() =>


### PR DESCRIPTION
Hello,

I reported https://github.com/freesewing/freesewing/issues/789 earlier
And I propose this fix.

The last commit is a bit unrelated it's juste UX homogenization between the different person edition pages 
(adding a cancel button and pushing cancel and save buttons to the right right)
It can be dropped if judged unnecessary.

What the added cancel button looks like on chest edition page:
![image](https://user-images.githubusercontent.com/3792171/104659058-423ffa80-56c4-11eb-84c0-fa42ffefa5b5.png)
