### PR TITLE
Update location of community calls

### DIFF
--- a/src/pages/community/calls/index.js
+++ b/src/pages/community/calls/index.js
@@ -37,8 +37,8 @@ const Page = (props) => {
       </p>
       <h5>How to connect</h5>
       <p>
-        We use Zoom for the call, and you can join at{' '}
-        <a href="https://meet.freesewing.org">meet.freesewing.org</a>.
+        We use Discord for the call, and you can join at{' '}
+        <a href="https://discord.freesewing.org">discord.freesewing.org</a>.
       </p>
       <h5 id="timezones">Contributor call in various timezones</h5>
       <ul className="links">


### PR DESCRIPTION
Updating location of community calls from Zoom to Discord on FreeSewing.org: https://freesewing.org/community/calls/