### PR TITLE
fix: change links to GitHub repos

### DIFF
--- a/src/components/draft/ui.js
+++ b/src/components/draft/ui.js
@@ -119,7 +119,7 @@ ${e.stack}
           compareWith,
         })
         .then((res) =>
-          setIssue(`https://github.com/freesewing/freesewing.org/issues/${res.data.id}`)
+          setIssue(`https://github.com/freesewing/freesewing/issues/${res.data.id}`)
         )
         .catch((err) => console.log(err))
         .finally(() => app.setLoading(false))

--- a/src/components/error.js
+++ b/src/components/error.js
@@ -17,7 +17,7 @@ const Error = ({ report = false, err = defaultError }) => {
           <Button
             variant="outlined"
             color="primary"
-            href="https://github.com/freesewing/website/issues/new"
+            href="https://github.com/freesewing/freesewing/issues/new"
             target="_BLANK"
           >
             <Icon icon="github" style={{ marginRight: '0.5rem' }} />


### PR DESCRIPTION
closes [issue #1145 in `freesewing`](https://github.com/freesewing/freesewing/issues/1145) and fixes link to deprecated `website` repo