### PR TITLE
Fix URL in generated PDF

### DIFF
--- a/src/components/draft/ui.js
+++ b/src/components/draft/ui.js
@@ -348,7 +348,8 @@ ${e.stack}
         data={data}
       />
     )
-  else if (display === 'export') main = <ExportPattern app={app} data={data} />
+  else if (display === 'export')
+    main = <ExportPattern app={app} data={data} handle={props.design} />
   else if (display === 'saveas')
     main = <SaveAsPattern app={app} data={data} person={props.person} />
   else

--- a/src/pages/patterns/_pattern/export.js
+++ b/src/pages/patterns/_pattern/export.js
@@ -47,7 +47,7 @@ const Page = (props) => {
         { title, slug: `/patterns/${props.params.pattern}/` },
       ]}
     >
-      <ExportPattern app={app} data={pattern.data} />
+      <ExportPattern app={app} data={pattern.data} handle={props.params.pattern} />
     </AppWrapper>
   )
 }


### PR DESCRIPTION
the handle for the pattern was not set in all cases. This resulted in the pattern having a URL of `https://freesewing.org/patterns/false`. This sets the handle in those places, so that the URLs in the generated PDF are correct.