### PR TITLE
Handle missing avatar in Person component

### DIFF
--- a/src/components/person.js
+++ b/src/components/person.js
@@ -33,7 +33,11 @@ const Person = (props) => {
         </ul>
       </div>
       <div className="avatar">
-        <img src={props.data.pictureUris.m} />
+        <img
+          src={
+            props.data.pictureUris ? props.data.pictureUris.m : 'https://freesewing.org/avatar.svg'
+          }
+        />
       </div>
       {props.link && <Link to={props.link} className="link" />}
     </div>


### PR DESCRIPTION
This is a bit of a blind fix because I haven't yet managed to get the site running locally, but this should hopefully fix an issue where any page using the `Person` component fails to render if that person hasn't been given an avatar, which is currently preventing me from using the site.