### PR TITLE
Add missing bustpointtounderbust.svg.

### DIFF
--- a/src/components/measurements/breasts/bustpointtounderbust.svg
+++ b/src/components/measurements/breasts/bustpointtounderbust.svg
@@ -1,0 +1,31 @@
+<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" width="2000" height="1500" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 2000 1500">
+    <defs>
+        <path id="path" d="M 180 0 c 0 20 2 35 -17 61 m 529 -76 c 0 15 0 38 -5 52" style="fill: none; stroke-linejoin: round;"/>
+    </defs>
+    <style type="text/css"><![CDATA[
+        path {fill: none; stroke-linejoin: round;}
+        .tape {stroke: #000; stroke-width: 20px; stroke-linecap: butt;}
+        .redtape {stroke: #f00; stroke-width: 1px;stroke-linecap: round;}
+        .color {stroke: #fff86c; stroke-width: 16px; stroke-linecap: butt;}
+        .cm {stroke: #000; stroke-width: 16px; stroke-dasharray: 2 10; stroke-linecap: butt;}
+        .line {stroke: #fff; stroke-width: 3px; stroke-dasharray: 8 5; stroke-linecap: round;}
+    ]]></style>
+
+    <!-- Background image -->
+    <image xlink:href="./standing.jpg" x="0" y="0" width="2000" height="1500" />
+
+    <g transform="translate(267 456)">
+        <use x="0" y="0" xlink:href="#path" class="redtape">
+            <animate attributeType="CSS" attributeName="stroke-width" from="1" to="450" begin="loop.begin+2.5s" dur="0.5s" fill="freeze" />
+            <animate attributeType="CSS" attributeName="stroke-opacity" from="1" to="0" begin="loop.begin+2.7s" dur="0.3s" fill="freeze" />
+        </use>
+        <use x="0" y="0" xlink:href="#path" class="tape"/>
+        <use x="0" y="0" xlink:href="#path" class="color"/>
+        <use x="0" y="0" xlink:href="#path" class="cm"/>
+    </g>
+
+    <!-- timing loop -->
+    <rect height="1" width="1" x="-10" y="-10">
+        <animate attributeType="CSS" attributeName="visibility" from="hide" to="hide" begin="0;loop.end" dur="4s" id="loop" />
+    </rect>
+</svg>

--- a/src/components/measurements/breasts/index.js
+++ b/src/components/measurements/breasts/index.js
@@ -2,6 +2,7 @@ import acrossback from './acrossback.svg'
 import ankle from './ankle.svg'
 import biceps from './biceps.svg'
 import bustfront from './bustfront.svg'
+import bustpointtounderbust from './bustpointtounderbust.svg'
 import bustspan from './bustspan.svg'
 import chest from './chest.svg'
 import crossseam from './crossseam.svg'
@@ -41,6 +42,7 @@ export default {
   ankle,
   biceps,
   bustfront,
+  bustpointtounderbust,
   bustspan,
   chest,
   crossseam,

--- a/src/components/measurements/images.js
+++ b/src/components/measurements/images.js
@@ -9,6 +9,7 @@ import { injectIntl } from 'react-intl'
 const seated = ['crotchdepth']
 const breastsOnly = [
   'ankle',
+  'bustpointtounderbust',
   'bustspan',
   'bustfront',
   'highbust',


### PR DESCRIPTION
I noticed this file was missing while adding some measurements:
![image](https://user-images.githubusercontent.com/9117775/148818025-5cdfcdd5-228f-4338-a8df-a593a01ea7d3.png)

I took a shot at creating one by copying an existing image and modifying the path. I would love to hear any suggestions for how this should actually look. Here is a screenshot of my image:
![image](https://user-images.githubusercontent.com/9117775/148817744-51bdd6f9-e5b1-4b95-b432-d25ccc7cb7a1.png)

Note that I wasn't able to find a reliable SVG editor that worked well with the files in this repo. I tried Inkscape and macSVG but couldn't get either to edit the paths. ~~I also wasn't able to get this repo running locally so I can't say with any confidence that this works on the actual site. I will ask for help on Discord.~~ (had to run `ln -s ../freesewing monorepo`)