### PR TITLE
Correct the hashtag URL

### DIFF
--- a/src/components/hashtag/index.js
+++ b/src/components/hashtag/index.js
@@ -3,7 +3,7 @@ import './hashtag.scss'
 import { Link } from 'gatsby'
 
 const Hashtag = ({ tag, title = '' }) => (
-  <Link className="hashtag" title={title} to="/share/">{`#${tag}`}</Link>
+  <Link className="hashtag" title={title} to="/community/share/">{`#${tag}`}</Link>
 )
 
 export default Hashtag


### PR DESCRIPTION
This fixes https://github.com/freesewing/freesewing/issues/2536 .
Because it appears that the original intent was to link to a "share" page, the fix changes the URL to https://freesewing.org/community/share/ . 